### PR TITLE
Cast lines attribute to array

### DIFF
--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -26,8 +26,7 @@ class Invoice extends Model
         'due_at',
     ];
 
-    public function getLinesAttribute($value)
-    {
-        return json_decode($value, true);
-    }
+    protected $casts = [
+        'lines' => 'array',
+    ];
 }

--- a/tests/Feature/Models/InvoiceTest.php
+++ b/tests/Feature/Models/InvoiceTest.php
@@ -35,10 +35,7 @@ class InvoiceTest extends TestCase
             ],
         ];
 
-        $lineString = json_encode($lines);
-        DB::table('invoices')->insert([
-            'lines' => $lineString
-        ]);
+        Invoice::create(['lines' => $lines]);
 
         $invoice = $this->invoice->first();
 


### PR DESCRIPTION
Hello !

J'ai remarqué que tu utilisais `json_encode`/`json_decode` manuellement dans tes exemples - tu peux aussi directement [cast les attributs d'un modèle Eloquent](https://laravel.com/docs/5.6/eloquent-mutators#array-and-json-casting) pour automatiser tout ça. C'est encore plus propre qu'utiliser les getters/setters !

Merci encore pour la présentation et au plaisir de se recroiser.

Cheers - Yannick